### PR TITLE
Refactor

### DIFF
--- a/rockspecs/time-sleep-dev-1.rockspec
+++ b/rockspecs/time-sleep-dev-1.rockspec
@@ -16,7 +16,7 @@ dependencies = {
     "lauxhlib >= 0.5.0",
 }
 build_dependencies = {
-    "luarocks-build-hooks >= 0.7.0",
+    "luarocks-build-hooks >= 0.8.0",
 }
 build = {
     type = "hooks",

--- a/src/lua_nanosleep.h
+++ b/src/lua_nanosleep.h
@@ -23,13 +23,13 @@
 #ifndef lua_nanosleep_h
 #define lua_nanosleep_h
 
+// depend
+#include <lauxhlib.h>
+#include <lua_errno.h>
+// system
 #include <errno.h>
 #include <math.h>
 #include <time.h>
-// lua
-#include <lauxhlib.h>
-#include <lua_errno.h>
-#include <sys/time.h>
 
 #define NSEC 1
 #define USEC (NSEC * 1000)


### PR DESCRIPTION
This pull request updates a build dependency version and refines header includes in the `src/lua_nanosleep.h` file to improve code organization and compatibility.

Dependency update:

* Updated the `luarocks-build-hooks` build dependency version from `>= 0.7.0` to `>= 0.8.0` in `rockspecs/time-sleep-dev-1.rockspec`, ensuring compatibility with newer build tooling.

Header include cleanup:

* Reorganized and clarified include statements in `src/lua_nanosleep.h` by grouping dependency and system headers separately, and removing the redundant inclusion of `<sys/time.h>`.